### PR TITLE
Allow Override of IP for blue/green in E2E tests

### DIFF
--- a/app/index.mjs
+++ b/app/index.mjs
@@ -2,6 +2,7 @@ import newman from 'newman'
 import commandLineArgs from 'command-line-args'
 import { getCollection, getCollectionJSON } from './collection'
 import { getEnv, getEnvJSON } from './environment'
+import evilDns from 'evil-dns';
 
 const optionDefinitions = [
   { name: 'collection', alias: 'c', type: String },
@@ -33,19 +34,35 @@ function runNewman(collectionJSON, envJSON) {
   });
 }
 
+function overrideDNS(domain,ip) {
+  evilDns.add('*.' + domain, ip);
+  console.warn('WARNING: ' + domain + ' overridden to IP ' + ip);
+}
+
 function checkArgs(options) {
   const valid = process.env.POSTMAN_API_TOKEN && options.collection && options.environment
-  if (!valid) {
+  const overRideIpValid = ! process.env.OVERRIDE_IP || (process.env.OVERRIDE_IP && process.env.DOMAIN)
+  if (!valid || !overRideIpValid) {
     console.log(`
   Required options not set.
 
   POSTMAN_API_TOKEN: Required environment variable | API token for postman
+  OVERRIDE_IP: Optional environment variable | override DNS queries to DOMAIN with this IP
+  DOMAIN: Required environment variable if OVERRIDE_IP is set | override DNS queries to this if OVERRIDE_IP is set
   collection, c: Required argument | Regex match of the collection name
   environment, e: Required argument | Regex match of the environment name
   updateEnvironment, u: Optional argument | Key value pairs of environment variables to override
 
   Example
-  newman-runner -c master -e master-dev -u DOMAIN=example.com
+    newman-runner -c master -e master-dev -u DOMAIN=example.com
+
+  Example with Ip override
+    export POSTMAN_API_TOKEN=abc123
+    export OVERRIDE_IP=10.11.12.13
+    export DOMAIN=example.com
+    newman-runner -c master -e master-dev -u DOMAIN=example.com
+
+
   `)
     process.exit(1)
   }
@@ -55,6 +72,8 @@ async function main() {
   const options = commandLineArgs(optionDefinitions)
   checkArgs(options)
 
+  if (process.env.OVERRIDE_IP)
+    overrideDNS(process.env.DOMAIN, process.env.OVERRIDE_IP);
 
   try {
     const env = await getEnv(options.environment.toLowerCase())

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "axios": "^0.18.0",
     "command-line-args": "^5.1.1",
     "esm": "^3.2.22",
+    "evil-dns": "^0.2.0",
     "newman": "^4.4.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -295,6 +295,11 @@ eventemitter3@3.1.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
   integrity sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==
 
+evil-dns@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/evil-dns/-/evil-dns-0.2.0.tgz#6ff64bf9c99a18df465458e6878ac570ea15d9b9"
+  integrity sha1-b/ZL+cmaGN9GVFjmh4rFcOoV2bk=
+
 extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"


### PR DESCRIPTION
Allow IP address to be overidden for DOMAIN in e2e tests.

Similar to https://github.com/ForgeCloud/ob-actuator-commit-healthcheck/pull/2

Usage:
```
OVERRIDE_IP=35.204.76.177 DOMAIN=master.forgerock.financial node app/index.js -e OBRI.master..Generated. -c ^End.To.End.Tests..Generated.$ -u DOMAIN=master.forgerock.financial
```